### PR TITLE
Fix for issue #19. Fix passing of label selectors when a service has …

### DIFF
--- a/wait_for.sh
+++ b/wait_for.sh
@@ -110,11 +110,11 @@ get_pod_state() {
 # example output with 2 services each matching a single pod would be: "falsefalse"
 get_service_state() {
     get_service_state_name="$1"
-    get_service_state_selectors=$(kubectl get service "$get_service_state_name" $KUBECTL_ARGS -ojson 2>&1 | jq -cr 'if . | has("items") then .items[] else . end | [ .spec.selector | to_entries[] | "-l\(.key)=\(.value)" ] | join(",") ')
+    get_service_state_selectors=$(kubectl get service "$get_service_state_name" $KUBECTL_ARGS -ojson 2>&1 | jq -cr 'if . | has("items") then .items[] else . end | [ .spec.selector | to_entries[] | "\(.key)=\(.value)" ] | join(",") ')
     get_service_state_states=""
     for get_service_state_selector in $get_service_state_selectors ; do
         get_service_state_selector=$(echo "$get_service_state_selector" | tr ',' ' ')
-        get_service_state_state=$(get_pod_state "$get_service_state_selectors")
+        get_service_state_state=$(get_pod_state -l"$get_service_state_selectors")
         get_service_state_states="${get_service_state_states}${get_service_state_state}" ;
     done
     echo "$get_service_state_states"


### PR DESCRIPTION
fixes #19 

When a service had more than 1 selector, they were being concatenated into a comma-separated list, but each item in the list had it's own `-l` flag.

This change moves the `-l` flag so that there would only be one.

**Note:**

Since there are no tests, I was only able to verify this fix in my own cluster. I'm not entirely sure that this would work in 100% of situations.